### PR TITLE
Error on AWS_DEFAULT_PROFILE not set

### DIFF
--- a/docker/run-local.sh
+++ b/docker/run-local.sh
@@ -28,6 +28,12 @@ then
     exit 1;
 fi
 
+if [ -z "$AWS_DEFAULT_PROFILE" ]
+then
+    echo "AWS_DEFAULT_PROFILE must be set!"
+    exit 1;
+fi
+
 CONTAINER="$PREFIX-$STAGE-pdal_runner"
 
 REGION=$AWS_DEFAULT_REGION


### PR DESCRIPTION
* if AWS_DEFAULT_PROFILE is not set, an error will be thrown, preventing the docker container from running erroneously